### PR TITLE
Okendo - Widget Plus Installation

### DIFF
--- a/config/settings_data.json
+++ b/config/settings_data.json
@@ -173,6 +173,13 @@
           "url_key": "hyttefeber.no",
           "lang": "no"
         }
+      },
+      "733389323033596483": {
+        "type": "shopify:\/\/apps\/okendo-product-reviews-ugc\/blocks\/theme-settings\/bb689e69-ea70-4661-8fb7-ad24a2e23c29",
+        "disabled": false,
+        "settings": {
+          "show_preview_data": false
+        }
       }
     }
   }

--- a/sections/featured-product.liquid
+++ b/sections/featured-product.liquid
@@ -76,6 +76,7 @@
                   {{ 'onboarding.product_title' | t }}
                 {%- endif -%}
               </h2>
+	    {% render 'okendo-reviews-product-rating-summary', product: product %}
             {%- when 'price' -%}
               <div class="no-js-hidden" id="price-{{ section.id }}" {{ block.shopify_attributes }}>
                 {%- render 'price', product: product, use_variant: true, show_badges: true, price_class: 'price--large' -%}
@@ -409,6 +410,21 @@
         }{% unless forloop.last %},{% endunless %}
       {%- endfor -%}
     ]
+    {% if product.metafields.okendo.summaryData.reviewCount > 0 %}
+    ,"aggregateRating": {
+      "@type": "AggregateRating",
+      "description": "Okendo Reviews",
+      "ratingValue": "{{ product.metafields.okendo.summaryData.reviewAverageValue }}",
+      "ratingCount": "{{ product.metafields.okendo.summaryData.reviewCount }}"
+    }
+    {% elsif product.metafields.okendo.ReviewCount > 0 %}
+    ,"aggregateRating": {
+      "@type": "AggregateRating",
+      "description": "Okendo Reviews",
+      "ratingValue": "{{ product.metafields.okendo.ReviewAverageValue }}",
+      "ratingCount": "{{ product.metafields.okendo.ReviewCount }}"
+    }
+    {% endif %}
   }
 </script>
 

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -99,6 +99,7 @@
             <h1 class="product__title" {{ block.shopify_attributes }}>
               {{ product.title | escape }}
             </h1>
+          {% render 'okendo-reviews-product-rating-summary', product: product %}
           {%- when 'price' -%}
             <div class="no-js-hidden" id="price-{{ section.id }}" {{ block.shopify_attributes }}>
               {%- render 'price', product: product, use_variant: true, show_badges: false, price_class: 'price--large' -%}
@@ -647,6 +648,21 @@
     {%- endif -%}
     {%- endif -%}
   {%- endif -%}
+  {% if product.metafields.okendo.summaryData.reviewCount > 0 %}
+  ,"aggregateRating": {
+    "@type": "AggregateRating",
+    "description": "Okendo Reviews",
+    "ratingValue": "{{ product.metafields.okendo.summaryData.reviewAverageValue }}",
+    "ratingCount": "{{ product.metafields.okendo.summaryData.reviewCount }}"
+  }
+  {% elsif product.metafields.okendo.ReviewCount > 0 %}
+  ,"aggregateRating": {
+    "@type": "AggregateRating",
+    "description": "Okendo Reviews",
+    "ratingValue": "{{ product.metafields.okendo.ReviewAverageValue }}",
+    "ratingCount": "{{ product.metafields.okendo.ReviewCount }}"
+  }
+  {% endif %}
 }
 </script>
 {%- endif -%}
@@ -659,6 +675,7 @@ richSnippet({
 });
 </script>
 
+{% render 'okendo-reviews-widget', product: product %}
 {% schema %}
 {
   "name": "t:sections.main-product.name",

--- a/snippets/okendo-reviews-product-rating-summary.liquid
+++ b/snippets/okendo-reviews-product-rating-summary.liquid
@@ -1,0 +1,6 @@
+{% if product.metafields.okendo.summaryData.reviewCount > 0 or product.metafields.okendo.reviewCount > 0 %}
+{% if product != blank %}
+    {% capture product_data_attribute %}data-oke-reviews-product-id="shopify-{{ product.id }}"{% endcapture %}
+{% endif %}
+<div data-oke-star-rating {{ product_data_attribute }}>{{ product.metafields.okendo.StarRatingSnippet }}</div>
+{% endif %}

--- a/snippets/okendo-reviews-widget.liquid
+++ b/snippets/okendo-reviews-widget.liquid
@@ -1,0 +1,9 @@
+{% if product != blank %}
+    {% capture product_data_attribute %}data-oke-reviews-product-id="shopify-{{ product.id }}"{% endcapture %}
+{% endif %}
+{% if shop.metafields.okendo.ReviewsWidgetStyles != blank %}
+{{ shop.metafields.okendo.ReviewsWidgetStyles }}
+{% endif %}
+<div class="page-width">
+    <div data-oke-widget {{ product_data_attribute }}>{{ product.metafields.okendo.ReviewsWidgetSnippet }}</div>
+</div>

--- a/snippets/product-card.liquid
+++ b/snippets/product-card.liquid
@@ -118,29 +118,10 @@
 
         {% comment %} TODO: metafield {% endcomment %}
         <span class="caption-large light">{{ block.settings.description | escape }}</span>
-        {%- if show_rating and product_card_product.metafields.reviews.rating.value != blank -%}
-          {% liquid
-            assign rating_decimal = 0
-            assign decimal = product_card_product.metafields.reviews.rating.value.rating | modulo: 1
-            if decimal >= 0.3 and decimal <= 0.7
-              assign rating_decimal = 0.5
-            elsif decimal > 0.7
-              assign rating_decimal = 1
-            endif
-          %}
-          <div class="rating" role="img" aria-label="{{ 'accessibility.star_reviews_info' | t: rating_value: product_card_product.metafields.reviews.rating.value, rating_max: product_card_product.metafields.reviews.rating.value.scale_max }}">
-            <span aria-hidden="true" class="rating-star color-icon-{{ settings.accent_icons }}" style="--rating: {{ product_card_product.metafields.reviews.rating.value.rating | floor }}; --rating-max: {{ product_card_product.metafields.reviews.rating.value.scale_max }}; --rating-decimal: {{ rating_decimal }};"></span>
-          </div>
-          <p class="rating-text caption">
-            <span aria-hidden="true">{{ product_card_product.metafields.reviews.rating.value }} / {{ product_card_product.metafields.reviews.rating.value.scale_max }}</span>
-          </p>
-          <p class="rating-count caption">
-            <span aria-hidden="true">({{ product_card_product.metafields.reviews.rating_count }})</span>
-            <span class="visually-hidden">{{ product_card_product.metafields.reviews.rating_count }} {{ "accessibility.total_reviews" | t }}</span>
-          </p>
+        {%- if show_rating -%}
+          {% render 'okendo-reviews-product-rating-summary', product: product_card_product %}
         {%- endif -%}
         {% render 'price', product: product_card_product, price_class: '' %}
-
       </div>
     </div>
   </a>
@@ -176,4 +157,3 @@
   {%- endif -%}
 </div>
 {%- render 'cart-notification' -%}
-


### PR DESCRIPTION
* Added Okendo App Embed to `settings_data.json` - toggled it on so widgets are enabled.
* Added Star Rating + Reviews Widget to the base of the product details page
* Added Star Rating to Product Cards if theme settings toggle "Show Reviews"
* Added reusable liquid snippets for Okendo Reviews Widget and Star Rating (`okendo-reviews-product-rating-summary.liquid`)